### PR TITLE
Updates for arm64 build

### DIFF
--- a/kafka/Dockerfile.ubi8
+++ b/kafka/Dockerfile.ubi8
@@ -14,13 +14,13 @@
 # limitations under the License.
 
 ARG DOCKER_UPSTREAM_REGISTRY
-ARG DOCKER_UPSTREAM_TAG=ubi8-latest
+ARG DOCKER_UPSTREAM_TAG=7.0.1
 
-FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-new:${DOCKER_UPSTREAM_TAG}
+FROM ${DOCKER_UPSTREAM_REGISTRY}dennisameling/cp-base-new:${DOCKER_UPSTREAM_TAG}
 
-ARG PROJECT_VERSION
-ARG ARTIFACT_ID
-ARG GIT_COMMIT
+ARG PROJECT_VERSION="7.0.1"
+ARG ARTIFACT_ID="cp-kafka"
+ARG GIT_COMMIT="unknown"
 
 LABEL maintainer="partner-support@confluent.io"
 LABEL vendor="Confluent"

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,14 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+    <repositories>
+        <repository>
+            <id>my-repo1</id>
+            <name>Maven Repository</name>
+            <url>https://packages.confluent.io/maven</url>
+        </repository>
+    </repositories>
+
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common-docker</artifactId>


### PR DESCRIPTION
The [`dockerfile-maven-plugin`](https://github.com/spotify/dockerfile-maven) that's being used here doesn't support `docker buildx` for building multi-arch Docker images and is not getting any further updates. Because of that I had to apply some manual hacks and build it as follows:

(the first command also builds the Java target which we'll need in the Docker build)

```shell
mvn clean package -Pdocker -DskipTests -Ddocker.registry="" -Ddocker.upstream.tag=7.0.1 -DCONFLUENT_PACKAGES_REPO=https://packages.confluent.io/rpm/7.0 -DCONFLUENT_VERSION=7.0.1
cd kafka
docker buildx build -f Dockerfile.ubi8 . --platform=linux/amd64,linux/arm64 --build-arg DOCKER_UPSTREAM_TAG=7.0.1 --build-arg CONFLUENT_PACKAGES_REPO=https://packages.confluent.io/rpm/7.0 --build-arg CONFLUENT_VERSION=7.0.1 -t dennisameling/cp-kafka:7.0.1 --push
```

Uses the custom `cp-base-new` which is also multi-arch: https://github.com/dennisameling/common-docker/pull/1 / https://hub.docker.com/r/dennisameling/cp-base-new/tags
Image for `dennisameling/cp-kafka` can be found at https://hub.docker.com/r/dennisameling/cp-kafka/tags